### PR TITLE
Amend test to use WebDriverWait

### DIFF
--- a/kalite/distributed/tests/ajax_messages_test.py
+++ b/kalite/distributed/tests/ajax_messages_test.py
@@ -1,4 +1,7 @@
-from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
 
 from kalite.testing.base import KALiteBrowserTestCase
 from kalite.testing.mixins import BrowserActionMixins, FacilityMixins
@@ -12,9 +15,9 @@ class TestShowAjaxMessages(BrowserActionMixins, FacilityMixins, KALiteBrowserTes
 
         self.browse_to(
             self.reverse("learn") + "khan/math/algebra/introduction-to-algebra/overview_hist_alg/origins-of-algebra/")
-        element = self.browser.find_element_by_css_selector("div.alert-warning").text
         try:
             warning = "This content was not found! You must login as an admin/coach to download the content."
-            self.assertTrue(warning in element)
-        except NoSuchElementException:
+            element = WebDriverWait(self.browser, 3).until(EC.presence_of_element_located((By.CSS_SELECTOR,"div.alert-warning")))
+            self.assertTrue(warning in element.text)
+        except TimeoutException:
             self.fail("Error: The element may not exist.")


### PR DESCRIPTION
Made changes as per my own suggestions, but with a caveat (below):

```
But it still could fail if the hardcoded video is downloaded
on the testing machine. Need to look on the testing machine and
pick an un-downloaded video.
```

Tagging [learningequality 3028](https://github.com/learningequality/ka-lite/pull/3028) to keep track of progress.