### PR TITLE
Remove absolute link

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -49,6 +49,9 @@ I would like to download the videos for KA Lite via BitTorrent, is this possible
 
 Yes! Please see the instructions for ":ref:`bulk-video-downloads`".
 
+
+.. _content_pack_retrieve_offline:
+
 How can I install a language pack without a reliable internet connection?
 -------------------------------------------------------------------------
 

--- a/docs/installguide/install_all.rst
+++ b/docs/installguide/install_all.rst
@@ -45,7 +45,12 @@ or use the command-line ``kalite`` program, which in typical installations can b
 ``C:\Python27\Scripts\kalite``. Run ``kalite --help`` for usage info.
 
 .. warning::
-    If you need to download and `install contentpacks locally <http://ka-lite.readthedocs.io/en/0.16.x/faq.html#how-can-i-install-a-language-pack-without-a-reliable-internet-connection>`_ for languages other than English, make sure you are doing it **as the same user that installed KA Lite** in the first place. If you perform the contentpack installation as a different user, some content will not load properly.
+    If you need to download and install contentpacks locally for languages other
+    than English, make sure you are doing it
+    **as the same user that installed KA Lite** in the first place. If you
+    perform the contentpack installation as a different user, some content will
+    not load properly. For downloading and installing content packs for offline
+    methods and automatic deployments, see :ref:`content_pack_retrieve_offline`.
 
 
 Mac OS X


### PR DESCRIPTION
The Sphinx rst should not refer to any absolute internet URLs.

1) For instance, readthedocs.org just changed to readthedocs.io
2) We host locally with a static build that's distributed together with KA Lite
3) Locations within the docs changes, the labels help us keep track of that

etc :)
